### PR TITLE
Lucene 710 uplift

### DIFF
--- a/app/services/LookupService.scala
+++ b/app/services/LookupService.scala
@@ -47,7 +47,7 @@ trait LookupService {
   }
 }
 
-case class SearchResult(numFound: Int, results: Seq[SicCode])
+case class SearchResult(numFound: Long, results: Seq[SicCode])
 object SearchResult { implicit val formats: Format[SearchResult] = Json.format[SearchResult] }
 
 @Singleton

--- a/it/api/SearchAPIISpec.scala
+++ b/it/api/SearchAPIISpec.scala
@@ -17,7 +17,7 @@
 package api
 
 import helpers.IntegrationSpecBase
-import play.api.libs.json.Json
+import play.api.libs.json.{JsArray, JsObject, Json}
 import play.api.libs.ws.WSResponse
 
 class SearchAPIISpec extends IntegrationSpecBase {
@@ -59,14 +59,19 @@ class SearchAPIISpec extends IntegrationSpecBase {
     }
 
     "supplying a valid query and requesting page 3 should return a 200 and the sic code descriptions skipping pages 1 & 2" in {
+
+      // get results from the beginning to the end of page 3
+      val pages1to3 = buildQueryAll(query, 15, 1).get().json
+      val p1to3docs = pages1to3.as[JsObject].value("results").as[JsArray]
+
       val sicCodeLookupResult = Json.obj(
         "numFound" -> 36,
         "results" -> Json.arr(
-          Json.obj("code" -> "46610005", "desc" -> "Dairy farm machinery (wholesale)"),
-          Json.obj("code" -> "46330004", "desc" -> "Dairy produce exporter (wholesale)"),
-          Json.obj("code" -> "46330005", "desc" -> "Dairy produce importer (wholesale)"),
-          Json.obj("code" -> "46330006", "desc" -> "Dairy produce n.e.c (wholesale)"),
-          Json.obj("code" -> "47290002", "desc" -> "Dairy products (retail)")
+          p1to3docs.value(10),
+          p1to3docs.value(11),
+          p1to3docs.value(12),
+          p1to3docs.value(13),
+          p1to3docs.value(14)
         )
       )
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -22,14 +22,12 @@ private object AppDependencies {
 }
 
 object LuceneDependencies {
-  private val luceneCoreVersion             = "6.6.1"
-  private val luceneQueryParserVersion      = "6.6.1"
-  private val luceneFacetVersion            = "6.6.1"
+  private val luceneVersion             = "7.1.0"
 
   def apply() = Seq(
-    "org.apache.lucene" % "lucene-core" % luceneCoreVersion,
-    "org.apache.lucene" % "lucene-queryparser" % luceneQueryParserVersion,
-    "org.apache.lucene" % "lucene-facet" % luceneFacetVersion
+    "org.apache.lucene" % "lucene-core" % luceneVersion,
+    "org.apache.lucene" % "lucene-queryparser" % luceneVersion,
+    "org.apache.lucene" % "lucene-facet" % luceneVersion
   )
 }
 

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+val luceneVersion             = "7.1.0"
+
 libraryDependencies ++= Seq(
-  "org.apache.lucene" % "lucene-core" % "6.6.1",
-  "org.apache.lucene" % "lucene-queryparser" % "6.6.1",
-  "org.apache.lucene" % "lucene-facet" % "6.6.1"
+  "org.apache.lucene" % "lucene-core" % luceneVersion,
+  "org.apache.lucene" % "lucene-queryparser" % luceneVersion,
+  "org.apache.lucene" % "lucene-facet" % luceneVersion
 )

--- a/test/lucene/SicIndexSpec.scala
+++ b/test/lucene/SicIndexSpec.scala
@@ -112,7 +112,7 @@ class SicIndexSpec extends UnitSpec {
 
           val result = searcher.search(qp.parse(data.query), 5)
 
-          result.totalHits should be >= data.numMin
+          result.totalHits.toInt should be >= data.numMin
 
           val results = result.scoreDocs.toSeq map {
             result =>


### PR DESCRIPTION
Refactored a test against Lucene 6.6.1 to get the search results for the first three pages, and used that to drive the page 3 assertion. Then, uplifted to 7.1.0 and test continued to pass.